### PR TITLE
feat/guia-pratico para gerentes de projeto

### DIFF
--- a/organizacao-interna/diretoria-projetos/gerencia-de-projetos/metodologias-ageis/gerente.md
+++ b/organizacao-interna/diretoria-projetos/gerencia-de-projetos/metodologias-ageis/gerente.md
@@ -1,0 +1,111 @@
+---
+label: "Guia Prático"
+icon: checklist
+author:
+  name: Henrique Givisiez dos Santos
+  avatar: ../assets/logo_struct.png
+date: 26-06-2025
+---
+
+# Guia Prático
+
+> Esta documentação complementa os guias oficiais da [Diretoria de Projetos da Struct](https://docs.structej.com/organizacao-interna/diretoria-projetos/gerencia-de-projetos/), com aprendizados práticos de ex-gerentes e observações úteis para o dia a dia na função.
+
+---
+
+## Mentalidade do(a) Gerente de Projetos
+
+- **Você é o ponto de articulação do time**: o gerente garante que todos estão na mesma página — cliente, equipe, PO, design, back e front.
+- **Responsabilidade ≠ Culpa**: assumir responsabilidades é diferente de carregar tudo sozinho.
+- **Iteração é poder**: busque progresso incremental, mesmo que pequeno, em vez de travar buscando uma entrega final perfeita.
+
+---
+
+## Planejamento e Metodologias Ágeis
+
+- **Prefira começar com um MVP**: concentre-se em algo funcional que possa ser evoluído com base em feedback.
+- **Não planeje tudo de uma vez**: comece com uma base sólida e vá detalhando ao longo do tempo.
+- **Use o Scrum + Kanban de forma realista**:
+  - Reuniões semanais (Scrum)
+  - Quadro de tarefas (Kanban) com *Issues* no GitHub Projects ou outra ferramenta de escolha do time
+- **Ferramentas úteis**:
+  - Slack: comunicação rápida
+  - GitHub Issues + Projects: gestão de tarefas
+  - Miro: modelagem de dados e fluxos
+  - Notion (opcional): documentação interna
+
+---
+
+## Comunicação com a Equipe
+
+- **Tenha reuniões frequentes e objetivas**: não precisam ser longas, mas devem ser constantes.
+- **Privacidade pode motivar**: converse em particular com quem estiver com dificuldades.
+- **Atenção aos períodos de prova**:
+  - Diminua carga de issues nesses momentos
+  - Alinhe prazos com antecedência
+- **Cobre com empatia, mas cobre**:
+  - Pessoas têm problemas, mas também têm responsabilidades.
+  - Combine o tom humano com clareza de expectativas.
+
+---
+
+## Interação com o Cliente
+
+- **Seja o filtro do time**: nem todo pedido do cliente deve virar uma nova tarefa sem análise.
+- **Documente e alinhe expectativas desde o início**:
+  - Evite escopo nebuloso
+  - Registre decisões importantes
+- **Cliente comunicativo ≠ cliente organizado**: lidere o alinhamento de requisitos, mesmo que ele pareça bem disposto.
+
+---
+
+## Lidando com Desafios
+
+- **Membros "fantasmas"? Reaja cedo**: identifique e redistribua tarefas rapidamente.
+- **Evite sobrecarga em poucos membros**: distribua responsabilidades desde o começo.
+- **Deploy e banco de dados** são frequentemente gargalos — planeje e peça ajuda quando necessário.
+- **Mudanças de escopo são inevitáveis**, mas devem ser:
+  - Priorizadas no roadmap
+  - Avaliadas em impacto
+  - Comunicadas ao time
+
+---
+
+## Dicas Práticas
+
+- **"Clean Code" não é só para devs**:
+  - Oriente o time a manter boas práticas nos repositórios
+  - Reforce princípios SOLID e separação de responsabilidades ([veja mais aqui](https://docs.structej.com/organizacao-interna/diretoria-projetos/gerencia-de-projetos/clean-code/))
+- **Garanta alinhamento entre Front e Back desde o início**:
+  - Promova reuniões técnicas conjuntas
+  - Valide as histórias de usuário com todos
+- **Valorize entregas contínuas**:
+  - Dê preferência a deploys incrementais (mesmo com funcionalidades parciais)
+  - Isso evita a "entrega surpresa" no final
+
+---
+
+## Conselhos Finais de Gerentes da Struct
+
+- “Use muito GitHub.”
+- “Não tenha medo de contatar os membros.”
+- “Entregar aos poucos sempre.”
+- “Não pegue leve na cobrança.”
+- “Dar maior atenção às demandas iniciais do projeto.”
+- “As metodologias de Scrum e Kanban são essenciais.”
+
+---
+
+## Checklist Rápido para Novos Gerentes
+
+- [ ] Reunião inicial com PO, design, back e front
+- [ ] Alinhamento com cliente (expectativas e escopo)
+- [ ] Quadro de Kanban com issues atualizadas
+- [ ] Estrutura de comunicação (Slack e reuniões semanais)
+- [ ] Planejamento de MVP + entregas incrementais
+- [ ] Acompanhamento da equipe (motivação e progresso)
+- [ ] Documentação das decisões e mudanças de escopo
+
+---
+
+> Esta documentação está viva — contribuições de novos gerentes são sempre bem-vindas!


### PR DESCRIPTION
# PR: Adiciona um guia prático para novos gerentes de projeto

## Descrição
Este PR adiciona ao DocStruct um guia Prático para novos gerentes de projeto, complementando os conteúdos já existentes na pasta de gerência (https://docs.structej.com/organizacao-interna/diretoria-projetos/gerencia-de-projetos/)

O guia foi construído com base em: 
 - Entrevistas realizadas com ex-gerentes de projeto da Struct (De Paula e Dan);
 - Documentação oficial disponível já existente;
 
## Conteúdo
 - Mentalidade do(a) gerente de projeto
 - Planejamento e metodologias ágeis adaptadas à realidade da Struct
 - Comunicação com equipe e cliente
 - Gestão de desafios comuns (tempo, escopo, produtividade)
 - Dicas práticas e conselhos de ex-gerentes
 - Checklist final para início de projetos

## Objetivo
Fornecer um material de consulta rápida, acessível e com exemplos práticos reais para novos gerentes ou membros da equipe que desejem compreender melhor o papel da gerência de projetos dentro da Struct.

**obs.: este guia não substitui a documentação oficial da diretoria de projetos, mas a complementa, com foco mais prático e adaptado à realidade dos membros**